### PR TITLE
Remove dependency on node-fetch

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-const fetch = require('node-fetch');
 const Bottleneck = require('bottleneck');
 const utils = require('./utils.js');
 const parser = require('./parser.js');

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "cheerio": "^1.0.0-rc.5",
     "html-entities": "^2.0.2",
     "node-cache": "^5.1.2",
-    "node-fetch": "^2.6.1",
     "safe-eval": "^0.4.1"
   }
 }


### PR DESCRIPTION
This dependency was producing a lot of warnings, and is no longer required as of Node.js version 18.

https://dev.to/andrewbaisden/the-nodejs-18-fetch-api-72m