### PR TITLE
Base OAuth implementation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/examples/oauth/oauth.mjs
+++ b/examples/oauth/oauth.mjs
@@ -1,0 +1,12 @@
+import bcfetch from '../../dist/mjs/index.js';
+
+bcfetch.setOAuth({
+  username: "username",
+  password: "asdfgjhsagdjks",
+  clientId: "134",
+  clientSecret: "1myK12VeCL3dWl9o/ncV2VyUUbOJuNPVJK6bZZJxHvk="
+})
+
+bcfetch.oauth.Login().then(e=>{
+  console.log(e);
+});

--- a/examples/oauth/oauth_output.txt
+++ b/examples/oauth/oauth_output.txt
@@ -1,0 +1,22 @@
+# With debug lines
+Sending headers: {
+  'Content-Type': 'application/x-www-form-urlencoded',
+  'X-Requested-With': 'com.bandcamp.android',
+  'X-Bandcamp-Dm': 'ef65c6dfba807f517cbe0bebfde404a93c9fce82'
+}
+Request body: grant_type=password&username=[redacted]&password=[redacted]&client_id=134&client_secret=1myK12VeCL3dWl9o%2FncV2VyUUbOJuNPVJK6bZZJxHvk%3D
+Received X-Bandcamp-Dm header: 74ae3af106a856a768ecbb039f25090ea4df68c17
+Sending headers: {
+  'Content-Type': 'application/x-www-form-urlencoded',
+  'X-Requested-With': 'com.bandcamp.android',
+  'X-Bandcamp-Dm': 'bc567063d4c0a6c560eca270df7135ff79673765'
+}
+Request body: grant_type=password&username=[redacted]&password=[redacted]&client_id=134&client_secret=1myK12VeCL3dWl9o%2FncV2VyUUbOJuNPVJK6bZZJxHvk%3D
+Received X-Bandcamp-Dm header: 74ae3af106a856a768ecbb039f25090ea4df68c17
+{
+  ok: true,
+  accessToken: '2859259703.134.1777934060.JfKdnJFWOiPif8fh83hFoE3=',
+  tokenType: 'bearer',
+  expiresIn: 3600,
+  refreshToken: '23702121.0.kOfIeFHshKegi/FkcdJd3+yHP6c='
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,13 @@
       "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
+        "axios": "^1.16.0",
+        "axios-cookiejar-support": "^6.0.5",
         "bottleneck": "^2.19.5",
         "cheerio": "^1.0.0",
         "html-entities": "^2.5.2",
-        "node-cache": "^5.1.2"
+        "node-cache": "^5.1.2",
+        "tough-cookie": "^6.0.1"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -589,6 +592,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -612,6 +624,77 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios-cookiejar-support": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-6.0.5.tgz",
+      "integrity": "sha512-ldPOQCJWB0ipugkTNVB8QRl/5L2UgfmVNVQtS9en1JQJ1wW588PqAmymnwmmgc12HLDzDtsJ28xE2ppj4rD4ng==",
+      "license": "MIT",
+      "dependencies": {
+        "http-cookie-agent": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/3846masa"
+      },
+      "peerDependencies": {
+        "axios": ">=0.20.0",
+        "tough-cookie": ">=4.0.0"
+      }
+    },
+    "node_modules/axios-cookiejar-support/node_modules/http-cookie-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-7.0.3.tgz",
+      "integrity": "sha512-EeZo7CGhfqPW6R006rJa4QtZZUpBygDa2HZH3DJqsTzTjyRE6foDBVQIv/pjVsxHC8z2GIdbB1Hvn9SRorP3WQ==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/3846masa"
+      },
+      "peerDependencies": {
+        "tough-cookie": "^4.0.0 || ^5.0.0 || ^6.0.0",
+        "undici": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "undici": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/axios-cookiejar-support/node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -646,6 +729,19 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/camelcase": {
@@ -710,6 +806,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -780,6 +888,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
@@ -835,6 +952,20 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/encoding-sniffer": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.0.tgz",
@@ -858,6 +989,51 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1157,6 +1333,88 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -1168,6 +1426,57 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/html-entities": {
@@ -1363,12 +1672,42 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/minimatch": {
       "version": "10.2.5",
@@ -1570,6 +1909,15 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1647,6 +1995,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/ts-api-utils": {

--- a/package.json
+++ b/package.json
@@ -55,10 +55,13 @@
     "typescript-eslint": "^8.58.0"
   },
   "dependencies": {
+    "axios": "^1.16.0",
+    "axios-cookiejar-support": "^6.0.5",
     "bottleneck": "^2.19.5",
     "cheerio": "^1.0.0",
     "html-entities": "^2.5.2",
-    "node-cache": "^5.1.2"
+    "node-cache": "^5.1.2",
+    "tough-cookie": "^6.0.1"
   },
   "keywords": [
     "bandcamp",

--- a/src/lib/BandcampFetch.ts
+++ b/src/lib/BandcampFetch.ts
@@ -8,16 +8,20 @@ import BandAPI, { LimiterBandAPI } from './band/BandAPI.js';
 import DiscoveryAPI, { LimiterDiscoveryAPI } from './discovery/DiscoveryAPI.js';
 import FanAPI, { LimiterFanAPI } from './fan/FanAPI.js';
 import ImageAPI, { LimiterImageAPI } from './image/ImageAPI.js';
+import OAuthAPI from './oauth/OAuth.js';
 import SearchAPI, { LimiterSearchAPI } from './search/SearchAPI.js';
 import ShowAPI, { LimiterShowAPI } from './show/ShowAPI.js';
+import StreamAPI, { LimiterStreamAPI } from './stream/StreamAPI.js';
 import TagAPI, { LimiterTagAPI } from './tag/TagAPI.js';
 import TrackAPI, { LimiterTrackAPI } from './track/TrackAPI.js';
+import type { BandcampOAuthLoginParams } from './types/OAuth.js';
 import Cache, { CacheDataType } from './utils/Cache.js';
 import Fetcher from './utils/Fetcher.js';
 import Limiter from './utils/Limiter.js';
-import StreamAPI, { LimiterStreamAPI } from './stream/StreamAPI.js';
+
 export interface BandcampFetchParams {
   cookie?: string | null;
+  oauth?: BandcampOAuthLoginParams;
 }
 
 export default class BandcampFetch {
@@ -39,6 +43,7 @@ export default class BandcampFetch {
   readonly search: SearchAPI;
   readonly autocomplete: AutocompleteAPI;
   readonly stream: StreamAPI;
+  oauth: OAuthAPI;
 
   readonly limiter: {
     readonly album: LimiterAlbumAPI;
@@ -68,7 +73,15 @@ export default class BandcampFetch {
     this.#wrappedCache = new CacheWrapper(this.#cache);
     this.#fetcher = new Fetcher({
       cookie: this.#cookie,
-      cache: this.#cache
+      cache: this.#cache,
+      preFetch: async (url, method, payload, headers) => {
+        if (url.includes('bandcamp.com')) {
+          if (this.oauth) {
+            headers['Authorization'] =
+              `Bearer ${await this.oauth.getAccessToken()}`;
+          }
+        }
+      }
     });
     this.#limiter = new Limiter();
 
@@ -96,6 +109,17 @@ export default class BandcampFetch {
     this.search = new SearchAPI(baseAPIWithImageSupportParams);
     this.autocomplete = new AutocompleteAPI(baseAPIParams);
     this.stream = new StreamAPI(baseAPIParams);
+    if (params?.oauth) {
+      const { username, password, clientId, clientSecret } = params.oauth;
+
+      this.oauth = new OAuthAPI(
+        this.#fetcher.client,
+        username,
+        password,
+        clientId,
+        clientSecret
+      );
+    }
 
     this.limiter = {
       album: new LimiterAlbumAPI(baseAPIWithImageSupportParams),
@@ -117,6 +141,22 @@ export default class BandcampFetch {
   setCookie(value?: string | null) {
     this.#cookie = value;
     this.#fetcher.setCookie(value);
+  }
+
+  setOAuth(params: BandcampOAuthLoginParams) {
+    const { username, password, clientId, clientSecret } = params;
+
+    if (!this.oauth) {
+      this.oauth = new OAuthAPI(
+        this.#fetcher.client,
+        username,
+        password,
+        clientId,
+        clientSecret
+      );
+    } else {
+      this.oauth.setParams(username, password, clientId, clientSecret);
+    }
   }
 
   get cookie() {

--- a/src/lib/BandcampFetch.ts
+++ b/src/lib/BandcampFetch.ts
@@ -88,7 +88,8 @@ export default class BandcampFetch {
     const baseAPIParams = {
       fetcher: this.#fetcher,
       cache: this.#cache,
-      limiter: this.#limiter
+      limiter: this.#limiter,
+      bandcamp: this
     };
     this.image = new ImageAPI(baseAPIParams);
 

--- a/src/lib/common/BaseAPI.ts
+++ b/src/lib/common/BaseAPI.ts
@@ -1,3 +1,4 @@
+import BandcampFetch from '../BandcampFetch.js';
 import type Cache from '../utils/Cache.js';
 import { type FetchMethod } from '../utils/Fetcher.js';
 import type Fetcher from '../utils/Fetcher.js';
@@ -5,15 +6,18 @@ import type Fetcher from '../utils/Fetcher.js';
 export interface BaseAPIParams {
   fetcher: Fetcher;
   cache: Cache;
+  bandcamp: BandcampFetch;
 }
 
 export default abstract class BaseAPI {
   #fetcher: Fetcher;
   #cache: Cache;
+  #bandcamp: BandcampFetch;
 
   constructor(params: BaseAPIParams) {
     this.#fetcher = params.fetcher;
     this.#cache = params.cache;
+    this.#bandcamp = params.bandcamp;
   }
 
   protected fetch(
@@ -44,7 +48,13 @@ export default abstract class BaseAPI {
     payload?: Record<string, any>,
     extraHeaders?: Record<string, string>
   ): Promise<any> {
-    return this.#fetcher.fetch(url, jsonResponse, method, payload, extraHeaders);
+    return this.#fetcher.fetch(
+      url,
+      jsonResponse,
+      method,
+      payload,
+      extraHeaders
+    );
   }
 
   protected get cache() {

--- a/src/lib/common/BaseAPI.ts
+++ b/src/lib/common/BaseAPI.ts
@@ -20,27 +20,31 @@ export default abstract class BaseAPI {
     url: string,
     jsonResponse: false,
     method: FetchMethod.HEAD,
-    payload?: undefined
+    payload?: undefined,
+    extraHeaders?: Record<string, string>
   ): Promise<{ ok: boolean; status: number }>;
   protected fetch(
     url: string,
     jsonResponse: true,
     method?: FetchMethod,
-    payload?: Record<string, any>
+    payload?: Record<string, any>,
+    extraHeaders?: Record<string, string>
   ): Promise<any>;
   protected fetch(
     url: string,
     jsonResponse?: boolean,
     method?: FetchMethod,
-    payload?: Record<string, any>
+    payload?: Record<string, any>,
+    extraHeaders?: Record<string, string>
   ): Promise<string>;
   protected fetch(
     url: string,
     jsonResponse?: boolean,
     method?: FetchMethod,
-    payload?: Record<string, any>
+    payload?: Record<string, any>,
+    extraHeaders?: Record<string, string>
   ): Promise<any> {
-    return this.#fetcher.fetch(url, jsonResponse, method, payload);
+    return this.#fetcher.fetch(url, jsonResponse, method, payload, extraHeaders);
   }
 
   protected get cache() {

--- a/src/lib/oauth/OAuth.ts
+++ b/src/lib/oauth/OAuth.ts
@@ -1,0 +1,204 @@
+import { type AxiosInstance, type AxiosResponse } from 'axios';
+import { URLSearchParams } from 'node:url';
+import type {
+  BandcampOAuthLoginParams,
+  BandcampOAuthTokenResponse
+} from '../types/OAuth.js';
+import { URLS } from '../utils/Constants.js';
+import { calculateDm, calculatePow } from '../utils/crypto/headers.js';
+import { camelizeKeys } from '../utils/Parse.js';
+
+const XBandcampDm: string = 'X-Bandcamp-Dm';
+const XBandcampPow: string = 'X-Bandcamp-Pow';
+
+export default class OAuthAPI {
+  #dm?: string = '';
+  #pow?: string;
+
+  #accessToken?: string;
+  #refreshToken?: string;
+  #accessTokenExpiresAt?: Date;
+
+  private readonly MAX_LOGIN_ATTEMPTS = 2;
+
+  private readonly RequestedWith: string = 'com.bandcamp.android';
+  private readonly ClientId: string = '134';
+  private readonly ClientSecret: string =
+    '1myK12VeCL3dWl9o/ncV2VyUUbOJuNPVJK6bZZJxHvk=';
+
+  private oauthParams: BandcampOAuthLoginParams;
+
+  private readonly client;
+
+  constructor(
+    client: AxiosInstance,
+    username: string,
+    password: string,
+    clientId: string = this.ClientId,
+    clientSecret = this.ClientSecret
+  ) {
+    this.client = client;
+    this.setParams(username, password, clientId, clientSecret);
+  }
+
+  setParams(
+    username: string,
+    password: string,
+    clientId: string = this.ClientId,
+    clientSecret = this.ClientSecret
+  ) {
+    this.oauthParams = {
+      username,
+      password,
+      clientId,
+      clientSecret
+    };
+  }
+
+  async login(
+    oauthParams: BandcampOAuthLoginParams = this.oauthParams
+  ): Promise<BandcampOAuthTokenResponse> {
+    this.oauthParams = oauthParams;
+
+    for (let i = 0; i < this.MAX_LOGIN_ATTEMPTS; i++) {
+      const content = this.#GetLoginParameters();
+      const response = await this.#sendRequest(content, URLS.OAUTH.LOGIN);
+
+      const status = response.status;
+      if (status === 418 || status === 451) continue;
+
+      if (status < 200 || status >= 300) {
+        throw new Error(
+          `Response status: ${status} : ${JSON.stringify(response.data) || response.statusText}`
+        );
+      }
+
+      return camelizeKeys<BandcampOAuthTokenResponse>(response.data);
+    }
+
+    throw new Error('Max number of login attempts exceeded.');
+  }
+
+  async refresh(): Promise<BandcampOAuthTokenResponse> {
+    for (let i = 0; i < this.MAX_LOGIN_ATTEMPTS; i++) {
+      const content = this.#GetRefreshParameters();
+      const response = await this.#sendRequest(content, URLS.OAUTH.TOKEN);
+
+      const status = response.status;
+      if (status === 418 || status === 451) continue;
+
+      if (status < 200 || status >= 300) {
+        throw new Error(
+          `Response status: ${response.status} : ${JSON.stringify(response.data) || response.statusText}`
+        );
+      }
+
+      const grantResponse = camelizeKeys<BandcampOAuthTokenResponse>(
+        response.data
+      );
+      this.#refreshToken = grantResponse.refreshToken;
+      this.#accessToken = grantResponse.accessToken;
+      this.#accessTokenExpiresAt = new Date(
+        Date.now() + grantResponse.expiresIn * 1000
+      );
+      return grantResponse;
+    }
+
+    throw new Error('Max number of refresh attempts exceeded.');
+  }
+
+  async revoke(): Promise<void> {
+    const content = this.#GetRevokeParameters();
+    const response = await this.#sendRequest(content, URLS.OAUTH.REVOKE);
+    if (!response.data.ok) {
+      throw new Error(`Revoke failed! ${JSON.stringify(response.data)}`);
+    }
+    this.#refreshToken = undefined;
+    this.#accessToken = undefined;
+  }
+
+  async getAccessToken(): Promise<string> {
+    if (
+      !this.#accessToken ||
+      (this.#accessTokenExpiresAt && new Date() >= this.#accessTokenExpiresAt)
+    ) {
+      await this.refresh();
+    }
+    return this.#accessToken!;
+  }
+
+  async #sendRequest(
+    params: URLSearchParams,
+    requestUri: string
+  ): Promise<AxiosResponse<BandcampOAuthTokenResponse>> {
+    const requestBody = params.toString();
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'X-Requested-With': this.RequestedWith,
+      [XBandcampDm]: calculateDm(this.#dm!, requestBody)
+    };
+
+    if (this.#pow != null) {
+      headers[XBandcampPow] = calculatePow(this.#pow, requestBody);
+    }
+
+    console.debug('Sending headers:', headers);
+    console.debug('Request body:', requestBody);
+
+    const response = await this.client.post(requestUri, requestBody, {
+      headers,
+      validateStatus: (status) => status < 500 // don't throw on 4xx
+    });
+
+    // update DM/POW from response headers if present
+    const dm = response.headers[XBandcampDm.toLowerCase()];
+    if (dm) {
+      this.#dm = Array.isArray(dm) ? dm[0] : dm;
+      console.debug(`Received ${XBandcampDm} header: ${this.#dm}`);
+    }
+
+    const pow = response.headers[XBandcampPow.toLowerCase()];
+    if (pow) {
+      this.#pow = Array.isArray(pow) ? pow[0] : pow;
+      console.debug(`Received ${XBandcampPow} header: ${this.#pow}`);
+    }
+
+    if (response.status >= 500) {
+      throw new Error(
+        `Server error ${response.status}: ${response.statusText}`
+      );
+    }
+
+    return response;
+  }
+
+  #GetLoginParameters() {
+    const params = new URLSearchParams();
+    params.append('grant_type', 'password');
+    params.append('username', this.oauthParams.username);
+    params.append('password', this.oauthParams.password);
+    params.append('client_id', this.oauthParams.clientId);
+    params.append('client_secret', this.oauthParams.clientSecret);
+    return params;
+  }
+
+  #GetRefreshParameters() {
+    if (!this.#refreshToken) throw new Error('No refresh token available.');
+    const params = new URLSearchParams();
+    params.append('grant_type', 'refresh_token');
+    params.append('refresh_token', this.#refreshToken);
+    params.append('client_id', this.oauthParams.clientId);
+    params.append('client_secret', this.oauthParams.clientSecret);
+    return params;
+  }
+
+  #GetRevokeParameters() {
+    if (!this.#refreshToken) throw new Error('No refresh token available.');
+    const params = new URLSearchParams();
+    params.append('refresh_token', this.#refreshToken);
+    params.append('client_id', this.oauthParams.clientId);
+    params.append('client_secret', this.oauthParams.clientSecret);
+    return params;
+  }
+}

--- a/src/lib/types/OAuth.ts
+++ b/src/lib/types/OAuth.ts
@@ -1,0 +1,20 @@
+export type BandcampOAuthLoginParams = {
+  clientId: string;
+  clientSecret: string;
+  password: string;
+  username: string;
+};
+
+export type BandcampOAuthRefreshParams = {
+  refeshToken: string;
+  clientId: string;
+  clientSecret: string;
+}
+
+export interface BandcampOAuthTokenResponse {
+  accessToken: string;
+  expiresIn: number;
+  ok: boolean;
+  refreshToken: string;
+  tokenType: string;
+}

--- a/src/lib/utils/Constants.ts
+++ b/src/lib/utils/Constants.ts
@@ -23,5 +23,11 @@ export const URLS = {
     TAG: `${API_URL}/bcsearch_public_api/1/tag_search`,
     LOCATION: `${API_URL}/location/1/geoname_search`
   },
-  REFRESH_STREAM: `${API_URL}/stream/1/refresh`
+  REFRESH_STREAM: `${API_URL}/stream/1/refresh`,
+  OAUTH: {
+    LOGIN: `${SITE_URL}/oauth_login`,
+    REVOKE: `${SITE_URL}/oauth_revoke`,
+    TOKEN: `${SITE_URL}/oauth_token`,
+    PRIME: `${API_URL}/mobile/26/prime`
+  }
 };

--- a/src/lib/utils/Fetcher.ts
+++ b/src/lib/utils/Fetcher.ts
@@ -1,6 +1,9 @@
 import { URL } from 'url';
 import type Cache from './Cache.js';
 import { CacheDataType } from './Cache.js';
+import axios, { type AxiosRequestConfig } from 'axios';
+import { wrapper } from 'axios-cookiejar-support';
+import { CookieJar } from 'tough-cookie';
 
 export enum FetchMethod {
   GET = 'GET',
@@ -8,118 +11,142 @@ export enum FetchMethod {
   HEAD = 'HEAD'
 }
 
+type PreFetchType = (
+  url: string,
+  method: string,
+  payload: Record<string, any> | undefined,
+  headers: Record<string, string>
+) => Promise<void> | void;
+
 export interface FetcherParams {
   cookie?: string | null;
   cache: Cache;
+  headers?: Record<string, string>;
+  preFetch?: PreFetchType;
 }
 
 export default class Fetcher {
   #cookie?: string | null;
   #cache: Cache;
+  #headers: Record<string, string> = {};
+  #preFetch?: PreFetchType;
+
+  private readonly jar = new CookieJar();
+  client;
 
   constructor(params: FetcherParams) {
     this.#cache = params.cache;
+    this.#headers = params.headers || {};
     this.setCookie(params.cookie);
+    this.#preFetch = params.preFetch;
+    this.client = wrapper(
+      axios.create({
+        jar: this.jar,
+        validateStatus: (status) => status < 500
+      })
+    );
   }
 
   setCookie(value?: string | null) {
-    this.#cookie = value;
     const valueChanged = (this.#cookie || null) !== (value || null);
+    this.#cookie = value;
     if (valueChanged) {
       this.#cache.clear();
+      if (value) {
+        this.jar.setCookieSync(value, '.bandcamp.com');
+      }
     }
+  }
+
+  setHeaders(headers: Record<string, string>) {
+    this.#headers = headers;
   }
 
   get cookie() {
-    return this.#cookie;
+    return this.jar.getCookieStringSync('.bamdcamp.com');
   }
 
-  fetch(
+  async fetch(
     url: string,
     jsonResponse: false,
     method: FetchMethod.HEAD,
-    payload?: undefined
+    payload?: undefined,
+    extraHeaders?: Record<string, string>
   ): Promise<{ ok: boolean; status: number }>;
-  fetch(
+  async fetch(
     url: string,
     jsonResponse: true,
     method?: FetchMethod,
-    payload?: Record<string, any>
+    payload?: Record<string, any>,
+    extraHeaders?: Record<string, string>
   ): Promise<any>;
-  fetch(
+  async fetch(
     url: string,
     jsonResponse?: boolean,
     method?: FetchMethod,
-    payload?: Record<string, any>
+    payload?: Record<string, any>,
+    extraHeaders?: Record<string, string>
   ): Promise<string>;
-  fetch(
+  async fetch(
     url: string,
-    jsonResponse?: boolean,
-    method?: FetchMethod,
-    payload?: Record<string, any>
+    jsonResponse: boolean = false,
+    method: FetchMethod = FetchMethod.GET,
+    payload?: Record<string, any>,
+    extraHeaders: Record<string, string> = {}
   ) {
-    if (jsonResponse === undefined) {
-      jsonResponse = false;
-    }
     return this.#cache.getOrSet(
       CacheDataType.Page,
       getCacheKey(url, jsonResponse, payload),
       async () => {
-        if (method === undefined) {
-          method = FetchMethod.GET;
+        const headers = { ...this.#headers, ...extraHeaders };
+
+        if (this.#preFetch) {
+          try {
+            await this.#preFetch(url, method, payload, headers);
+          } catch (error) {
+            throw new FetchError({
+              message: `preFetch failed: ${error instanceof Error ? error.message : (error as any)}`,
+              stack: error instanceof Error ? error.stack : undefined
+            });
+          }
         }
 
         if (method === FetchMethod.HEAD) {
-          const response = await fetch(url, { method: 'HEAD' });
-          return {
-            ok: response.ok,
-            status: response.status
-          };
+          const response = await this.client.head(url, { headers });
+          return { ok: response.status < 400, status: response.status };
         }
 
-        let response;
-        if (method === FetchMethod.GET) {
+        const config: AxiosRequestConfig = { headers };
+
+        if (method === FetchMethod.GET && payload) {
           const urlObj = new URL(url);
-          if (payload) {
-            for (const [key, value] of Object.entries(payload)) {
-              urlObj.searchParams.set(key, value);
-            }
-          }
-          try {
-            const request = new Request(urlObj.toString());
-            if (this.#cookie) {
-              request.headers.set('Cookie', this.#cookie);
-            }
-            response = await fetch(request);
-          } catch (error) {
-            throw new FetchError(error);
-          }
-        } else {
-          const init: RequestInit = {
-            method: 'POST',
-            body: payload ? JSON.stringify(payload) : undefined
-          };
-          const request = new Request(url);
-          request.headers.set('Content-Type', 'application/json');
-          if (this.#cookie) {
-            request.headers.set('Cookie', this.#cookie);
-          }
-          try {
-            response = await fetch(request, init);
-          } catch (error) {
-            throw new FetchError(error);
-          }
+          Object.entries(payload).forEach(([k, v]) =>
+            urlObj.searchParams.set(k, v)
+          );
+          url = urlObj.toString();
+        } else if (method !== FetchMethod.GET) {
+          headers['Content-Type'] = 'application/json';
+          config.data = payload;
         }
-        if (response.status === 429) {
-          throw new FetchError({
-            message: '429 Too Many Requests',
-            code: 429
+
+        try {
+          const response = await this.client.request({
+            url,
+            method: method.toLowerCase(),
+            ...config
           });
+
+          if (response.status === 429) {
+            throw new FetchError({
+              message: '429 Too Many Requests',
+              code: 429
+            });
+          }
+
+          return jsonResponse ? response.data : response.data.toString();
+        } catch (error) {
+          throw error instanceof FetchError ? error : new FetchError(error);
         }
-        if (jsonResponse) {
-          return response.json();
-        }
-        return response.text();
       }
     );
   }

--- a/src/lib/utils/Parse.ts
+++ b/src/lib/utils/Parse.ts
@@ -182,3 +182,26 @@ export class ParseError extends Error {
     }
   }
 }
+
+export function camelizeKeys<T>(obj: T): T {
+  if (obj === null || obj === undefined) return obj;
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => camelizeKeys(item)) as unknown as T;
+  }
+
+  if (typeof obj === 'object') {
+    const result: any = {};
+    for (const key in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        const camelKey = key.replace(/_([a-z])/g, (_, char) =>
+          char.toUpperCase()
+        );
+        result[camelKey] = camelizeKeys((obj as any)[key]);
+      }
+    }
+    return result as T;
+  }
+
+  return obj;
+}

--- a/src/lib/utils/Strings.ts
+++ b/src/lib/utils/Strings.ts
@@ -1,0 +1,17 @@
+export function reverseString(str: string): string {
+    return str.split('').reverse().join('');
+}
+
+export function lastCharToInt(str: string): number {
+    const lastChar = str[str.length - 1];
+    return parseInt(lastChar, 10) || 0;
+}
+
+export function charToInt(str: string, index: number): number {
+    const char = str[index];
+    return parseInt(char, 10) || 0;
+}
+
+export function toBase36(num: number): string {
+    return num.toString(36);
+}

--- a/src/lib/utils/crypto/Sha1Kdf.ts
+++ b/src/lib/utils/crypto/Sha1Kdf.ts
@@ -1,0 +1,27 @@
+import { hmacSha1 } from './common.js';
+
+export default {
+  deriveKey(algorithm: number, dm: string | null): string {
+    if (dm == null) {
+      return '';
+    }
+
+    if (algorithm === 1) {
+      return dm.substring(0, 19) + dm.substring(22);
+    }
+
+    let key = dm.toUpperCase();
+    const floor = Math.floor(key.length / 2);
+
+    const reverseString = (str: string) => str.split('').reverse().join('');
+
+    key =
+      reverseString(key.substring(0, floor)) +
+      reverseString(key.substring(floor));
+    key = key.substring(0, 15) + key.substring(19);
+    key = key.replace(/4/g, '1');
+    key = hmacSha1('bntpd', key);
+
+    return key.replace(/3/g, '5');
+  }
+};

--- a/src/lib/utils/crypto/Sha256KdfV1.ts
+++ b/src/lib/utils/crypto/Sha256KdfV1.ts
@@ -1,0 +1,24 @@
+import { lastCharToInt, reverseString } from "../Strings.js";
+import { hmacSha256 } from "./common.js";
+
+const KEY_V1 =
+	"1YlODulAdUFx6qKC3PzI5QP9gGuhPdIG" +
+	"xCQJz25vTiwiDRbhZRdmz89NGmNOy5FM" +
+	"vqcGAbRi3vrBD6vbwQriX2PSs9iRfWpc" +
+	"G4kn9mlPbwQRjWVAtiwb5PMKNTcuuY92";
+
+export default {
+	deriveKey(dm: string): string {
+		let key = KEY_V1;
+		const iterations = (lastCharToInt(dm) * 3) % 4;
+
+		for (let i = 0; i < iterations; i++) {
+			const mid = Math.floor(key.length / 2);
+			const s1 = reverseString(key.substring(0, mid));
+			const s2 = reverseString(key.substring(mid)).toUpperCase();
+			key = hmacSha256(key, s1 + s2);
+		}
+
+		return key;
+	},
+};

--- a/src/lib/utils/crypto/Sha256KdfV2.ts
+++ b/src/lib/utils/crypto/Sha256KdfV2.ts
@@ -1,0 +1,24 @@
+import { lastCharToInt, reverseString } from '../Strings.js';
+import { hmacSha256 } from './common.js';
+
+const KEY_V2 =
+  'YvtxhlQJoACdthoZcZaFlxmc62BN2HC5' +
+  '7hwG64vSd90EPXfIetlovBmh9cfHkUN7' +
+  'gvNj6iEbqQReseKxFcrjaESLZDxQbva4' +
+  'jIBht7R27dmrussXayASiJ0YPnXZIJZs';
+
+export default {
+  deriveKey(dm: string): string {
+    let key = KEY_V2;
+    const iterations = lastCharToInt(dm);
+
+    for (let i = 0; i < iterations; i++) {
+      const mid = Math.floor(key.length / 2);
+      const s1 = reverseString(key.substring(0, mid));
+      const s2 = reverseString(key.substring(mid));
+      key = hmacSha256(key, s1 + s2);
+    }
+
+    return hmacSha256(key, dm);
+  }
+};

--- a/src/lib/utils/crypto/common.ts
+++ b/src/lib/utils/crypto/common.ts
@@ -1,0 +1,11 @@
+// NOTICE: All code in this folder has been ported from https://github.com/Metalnem/bandcamp-downloader, licensed under MIT, see the license here https://github.com/Metalnem/bandcamp-downloader/blob/main/LICENSE
+// + ../Strings.ts
+import crypto from 'crypto';
+
+export function hmacSha256(key: string, source: string): string {
+  return crypto.createHmac('sha256', key).update(source).digest('hex');
+}
+
+export function hmacSha1(key: string, source: string): string {
+  return crypto.createHmac('sha1', key).update(source).digest('hex');
+}

--- a/src/lib/utils/crypto/headers.ts
+++ b/src/lib/utils/crypto/headers.ts
@@ -1,0 +1,58 @@
+import crypto from "crypto";
+import { charToInt, lastCharToInt, toBase36 } from "../Strings.js";
+import { hmacSha1, hmacSha256 } from "./common.js";
+import Sha1Kdf from "./Sha1Kdf.js";
+import Sha256KdfV1 from "./Sha256KdfV1.js";
+import Sha256KdfV2 from "./Sha256KdfV2.js";
+
+const AlgorithmHmacSha256 = 3;
+const AlgorithmHmacSha512 = 4;
+
+export function calculateDm(dm: string, requestBody: string): string {
+	let algorithm = 0;
+
+	if (dm) {
+		const index = lastCharToInt(dm);
+		algorithm = charToInt(dm, index);
+	}
+
+	if (algorithm === AlgorithmHmacSha256) {
+		const key = Sha256KdfV1.deriveKey(dm);
+		const prefix = Sha256KdfV2.deriveKey(dm);
+		return hmacSha256(key, prefix + requestBody);
+	}
+
+	if (algorithm === AlgorithmHmacSha512) {
+		throw new Error("HMAC SHA-512 KDF is currently not supported.");
+	}
+
+	return hmacSha1("dtmfa", Sha1Kdf.deriveKey(algorithm, dm) + requestBody);
+}
+
+export function calculatePow(pow: string, requestBody: string): string {
+	const parts = pow.split(":");
+	const data = requestBody + parts[2];
+	const leadingZeroBits = parseInt(parts[1], 10);
+	const nonce = calculateNonce(data, leadingZeroBits);
+	return `${parts[0]}:${parts[1]}:${parts[2]}:${nonce}`;
+}
+
+function calculateNonce(data: string, leadingZeroBits: number): string {
+	let nonce = 0;
+	while (true) {
+		const result = toBase36(nonce++);
+		const digest = crypto
+			.createHash("sha1")
+			.update(data + result)
+			.digest();
+
+		let total = 0;
+		for (const byte of digest) {
+			const count = Math.clz32(byte) - 24;
+			total += count;
+			if (count < 8) break;
+		}
+
+		if (total >= leadingZeroBits) return result;
+	}
+}


### PR DESCRIPTION
This PR implements the full auth flow required for OAuth for bandcamp, which will allow us to use more APIs instead of relying on scraping webpages so we can get more accurate API data. I'm opening this as a draft to hopefully bring in some discussion about anything else that could be added, or unwanted changes

Right now the only thing I have considered is playlists, which require authentication.
```
PLAYLIST: {
    FETCH_INDIVIDUAL: `${API_URL}/playlist/1/app_owned_playlist_details`,
    FETCH_ALL: `${API_URL}/playlist/1/fetch`,
    SAVE: `${API_URL}/playlist/1/save`,
    MAKE_IMAGE: `${API_URL}/playlist/1/make_image`,
    SET_VISIBILITY: `${API_URL}/playlist/1/set_visibility`
  },
```

I've implemented the full oauth flow based on @metalnem's [Bandcamp Downloader](https://github.com/Metalnem/bandcamp-downloader/) and this article on the subject https://mijailovic.net/2024/04/04/bandcamp-auth/

This would be the first big PR I've worked on in a long time for a library. My main goal of this is to have more actual api requests added to this library rather than scraping webpages unnecessarily.

# Changelog
- Fetch has been swapped out with Axios wrapped with [Cookie jar support](https://www.npmjs.com/package/axios-cookiejar-support), so OAuth can use the client and persist cookies throughout login requests
- Added extraHeaders to `Fetcher.fetch`
- Added oauth lib/class that integrates with a passed in axios client (aka the fetcher of a BandcampFetch instance)
- Added preFetch function to be passed to the fetcher before fetching